### PR TITLE
Fix README and test for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ var bs58 = require('base-x')(BASE58)
 var decoded = bs58.decode('5Kd3NBUAdUnhyzenEwVLy9pBKxSwXvE9FMPyR4UKZvpe6E3AgLr')
 
 console.log(decoded)
-// => [128,237,219,220,17,104,241,218,234,219,211,228,76,10,106,249,133,131,164,153,222,91,25,19,164,248,99]
-
-console.log(Buffer.from(decoded))
 // => <Buffer 80 ed db dc 11 68 f1 da ea db d3 e4 4c 1e 3f 8f 5a 28 4c 20 29 f7 8a d2 6a f9 85 83 a4 99 de 5b 19>
 
 console.log(bs58.encode(decoded))

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ fixtures.valid.forEach(function (f) {
 fixtures.valid.forEach(function (f) {
   tape.test('can decode ' + f.alphabet + ': ' + f.string, function (t) {
     var base = bases[f.alphabet]
-    var actual = Buffer.from(base.decode(f.string)).toString('hex')
+    var actual = base.decode(f.string).toString('hex')
 
     t.same(actual, f.hex)
     t.end()


### PR DESCRIPTION
* Document correctly that `decode()` returns `Buffer` instead of `Array`.
* Drop unnecessary `Buffer.from([buffer])` from tests.