### PR TITLE
Only node >= 4.5.0 (Buffer.allocUnsafe/Buffer.from)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   "devDependencies": {
     "standard": "^6.0.8",
     "tape": "^4.5.1"
+  },
+  "engines": {
+    "node": ">=4.5.0"
   }
 }


### PR DESCRIPTION
`Buffer.allocUnsafe`/`Buffer.from` available only from `4.5.0`