### PR TITLE
Node < 6 shim for Buffer.from

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 // Copyright (c) 2013 BitPay Inc
 
 module.exports = function base (ALPHABET) {
+  var bufferFrom = require('./lib/buffer-from')
   var ALPHABET_MAP = {}
   var BASE = ALPHABET.length
   var LEADER = ALPHABET.charAt(0)
@@ -71,7 +72,7 @@ module.exports = function base (ALPHABET) {
       bytes.push(0)
     }
 
-    return Buffer.from(bytes.reverse())
+    return bufferFrom(bytes.reverse())
   }
 
   function decode (string) {

--- a/lib/buffer-from.js
+++ b/lib/buffer-from.js
@@ -1,0 +1,14 @@
+module.exports = function bufferFrom (bytes) {
+  try {
+    return Buffer.from(bytes)
+  } catch (err) {
+    // Prior to node 6, Buffer defines the from method, but it is not
+    // documented, and it throws this error.
+    if (err.toString() === 'TypeError: this is not a typed array.') {
+      // Fall back to constructor
+      return new Buffer(bytes)
+    } else {
+      throw err
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "license": "MIT",
   "author": "Daniel Cousens",
   "files": [
-    "index.js"
+    "index.js",
+    "lib/buffer-from.js"
   ],
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
See http://stackoverflow.com/questions/36899888/getting-typeerror-this-is-not-a-typed-array-using-buffer-from-in-mocha

I can't use the upgrade option, because I want to use this on AWS Lambda, and currently they only support up to 4.3. See http://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html
