### PR TITLE
Safe Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,4 @@ assert hex(12345) == '0x3039'
 
 Of course the input is actually an array of digits already :)
 
-### Using base-x in Legacy Versions of Node (below 4.5)
-
-If you are using base-x in Node versions below `4.5.0`, please use `base-x ^2.0.0`.
-`base-x ^3.0.0` uses `Buffer.from` which is not supported prior to Node `4.5.0`.
-
-## License [MIT](LICENSE)
+## LICENSE [MIT](LICENSE)

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@
 // Merged Buffer refactorings from base58-native by Stephen Pair
 // Copyright (c) 2013 BitPay Inc
 
+var Buffer = require('safe-buffer').Buffer
+
 module.exports = function base (ALPHABET) {
   var ALPHABET_MAP = {}
   var BASE = ALPHABET.length

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-x",
-  "version": "3.0.0",
+  "version": "2.0.6",
   "description": "Fast base encoding / decoding of any given alphabet",
   "keywords": [
     "base-x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-x",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Fast base encoding / decoding of any given alphabet",
   "keywords": [
     "base-x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-x",
-  "version": "2.0.6",
+  "version": "3.0.0",
   "description": "Fast base encoding / decoding of any given alphabet",
   "keywords": [
     "base-x",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "standard": "^6.0.8",
     "tape": "^4.5.1"
   },
-  "engines": {
-    "node": ">=4.5.0"
-  },
   "dependencies": {
     "safe-buffer": "^5.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   },
   "engines": {
     "node": ">=4.5.0"
+  },
+  "dependencies": {
+    "safe-buffer": "^5.0.1"
   }
 }


### PR DESCRIPTION
Would release as `2.0.6` and `3.0.1`... ideally we'd deprecate `^3.0.0` and ask users to revert to `^2.0.0`,  seeing as the only change was the engine requirement (which we've now alleviated).

Thoughts?