### PR TITLE
fix(encode): allow source to be null

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function base (ALPHABET) {
   }
 
   function encode (source) {
-    if (source.length === 0) return ''
+    if (source === null || source.length === 0) return ''
 
     var digits = [0]
     for (var i = 0; i < source.length; ++i) {


### PR DESCRIPTION
Simple improvement to `encode`.  Needed by https://github.com/ipfs/js-ipfs/issues/1066