### PR TITLE
add (and fix) failing test case for {}

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ module.exports = function base (ALPHABET) {
   }
 
   function decodeUnsafe (string) {
+    if (typeof string !== 'string') throw new TypeError('Expected String')
     if (string.length === 0) return Buffer.allocUnsafe(0)
 
     var bytes = [0]

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -551,6 +551,12 @@
     {
       "alphabet": "base58",
       "description": "non-base58 string",
+      "exception": "^TypeError: Expected String$",
+      "string": {}
+    },
+    {
+      "alphabet": "base58",
+      "description": "non-base58 string",
       "exception": "^Error: Non-base58 character$",
       "string": "#####"
     },


### PR DESCRIPTION
Burned by this, `{}` returns `<Buffer 00>`...