### PR TITLE
Gracefully accept string input to encode

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ module.exports = function base (ALPHABET) {
   }
 
   function encode (source) {
+    if (!Buffer.isBuffer(source)) throw new TypeError('Expected Buffer')
+
     if (source.length === 0) return ''
 
     var digits = [0]

--- a/test/index.js
+++ b/test/index.js
@@ -47,3 +47,12 @@ tape.test('decode should return Buffer', function (t) {
 
   t.end()
 })
+
+tape.test('encode throws on string', function (t) {
+  var base = bases.base58
+
+  t.throws(function () {
+    base.encode('a')
+  }, new RegExp('^TypeError: Expected Buffer$'))
+  t.end()
+})


### PR DESCRIPTION
Since strings behave similarly to Buffers (they have `.length` and can be indexed via `[]`) the encode function accepts them, but returns ultimately erroneous output.  That is, the string returned will not `decode` back into the original string passed to `encode`.

Originally in #48 I thought that input validation was the answer, however because there are already several valid buffer types (Buffer, Int8Array) that do work, it seemed a better practice to simply cast a string to a Buffer if one is passed in.  The default encoding was used since that's also the default encoding on a string and I felt that was a safe assumption to make (if a string is being passed in it's actually a utf8 string).

The existing test fixtures don't really work with this, and most of them are using input that doesn't translate cleanly to a utf8 string so I just added a hard coded test to the end of the suite.