### PR TITLE
Specify node version requirements in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "base-x",
   "version": "3.0.5",
   "description": "Fast base encoding / decoding of any given alphabet",
+  "engines" : { 
+    "node" : ">=6.0.0" 
+  }, 
   "keywords": [
     "base-x",
     "base58",


### PR DESCRIPTION
The latest release to 3.0.5 introduced es6 syntax which makes using base-x difficult as a dependency. This has been the case with me and I'm sure with other developers that have not yet made the switch over to es6. 

Introducing constraint so that npm is aware that 3.0.5 only works with node versions greater than 6.