### PR TITLE
Support TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 
 npm-debug.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-x",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Fast base encoding / decoding of any given alphabet",
   "keywords": [
     "base-x",
@@ -21,21 +21,27 @@
   "license": "MIT",
   "author": "Daniel Cousens",
   "files": [
-    "index.js"
+    "src"
   ],
-  "main": "index.js",
+  "main": "src/index.js",
+  "types": "src/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/cryptocoinjs/base-x.git"
   },
   "scripts": {
+    "build": "tsc -p ./tsconfig.json ; standard --fix",
+    "gitdiff": "npm run build && git diff --exit-code",
+    "prepublish": "npm run gitdiff",
     "standard": "standard",
     "test": "npm run unit && npm run standard",
     "unit": "tape test/*.js"
   },
   "devDependencies": {
+    "@types/node": "12.0.10",
     "standard": "^10.0.3",
-    "tape": "^4.5.1"
+    "tape": "^4.5.1",
+    "typescript": "3.5.2"
   },
   "dependencies": {
     "safe-buffer": "^5.0.1"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="node" />
+declare function base(ALPHABET: string): {
+    encode: (source: Buffer) => string;
+    decodeUnsafe: (source: string) => Buffer | undefined;
+    decode: (string: string) => Buffer;
+};
+export = base;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,120 @@
+'use strict'
+// base-x encoding / decoding
+// Copyright (c) 2018 base-x contributors
+// Copyright (c) 2014-2018 The Bitcoin Core developers (base58.cpp)
+// Distributed under the MIT software license, see the accompanying
+// file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+// @ts-ignore
+var _Buffer = require('safe-buffer').Buffer
+function base (ALPHABET) {
+  if (ALPHABET.length >= 255) { throw new TypeError('Alphabet too long') }
+  var BASE_MAP = new Uint8Array(256)
+  BASE_MAP.fill(255)
+  for (var i = 0; i < ALPHABET.length; i++) {
+    var x = ALPHABET.charAt(i)
+    var xc = x.charCodeAt(0)
+    if (BASE_MAP[xc] !== 255) { throw new TypeError(x + ' is ambiguous') }
+    BASE_MAP[xc] = i
+  }
+  var BASE = ALPHABET.length
+  var LEADER = ALPHABET.charAt(0)
+  var FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
+  var iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
+  function encode (source) {
+    if (!_Buffer.isBuffer(source)) { throw new TypeError('Expected Buffer') }
+    if (source.length === 0) { return '' }
+        // Skip & count leading zeroes.
+    var zeroes = 0
+    var length = 0
+    var pbegin = 0
+    var pend = source.length
+    while (pbegin !== pend && source[pbegin] === 0) {
+      pbegin++
+      zeroes++
+    }
+        // Allocate enough space in big-endian base58 representation.
+    var size = ((pend - pbegin) * iFACTOR + 1) >>> 0
+    var b58 = new Uint8Array(size)
+        // Process the bytes.
+    while (pbegin !== pend) {
+      var carry = source[pbegin]
+            // Apply "b58 = b58 * 256 + ch".
+      var i = 0
+      for (var it1 = size - 1; (carry !== 0 || i < length) && (it1 !== -1); it1--, i++) {
+        carry += (256 * b58[it1]) >>> 0
+        b58[it1] = (carry % BASE) >>> 0
+        carry = (carry / BASE) >>> 0
+      }
+      if (carry !== 0) { throw new Error('Non-zero carry') }
+      length = i
+      pbegin++
+    }
+        // Skip leading zeroes in base58 result.
+    var it2 = size - length
+    while (it2 !== size && b58[it2] === 0) {
+      it2++
+    }
+        // Translate the result into a string.
+    var str = LEADER.repeat(zeroes)
+    for (; it2 < size; ++it2) { str += ALPHABET.charAt(b58[it2]) }
+    return str
+  }
+  function decodeUnsafe (source) {
+    if (typeof source !== 'string') { throw new TypeError('Expected String') }
+    if (source.length === 0) { return _Buffer.alloc(0) }
+    var psz = 0
+        // Skip leading spaces.
+    if (source[psz] === ' ') { return }
+        // Skip and count leading '1's.
+    var zeroes = 0
+    var length = 0
+    while (source[psz] === LEADER) {
+      zeroes++
+      psz++
+    }
+        // Allocate enough space in big-endian base256 representation.
+    var size = (((source.length - psz) * FACTOR) + 1) >>> 0 // log(58) / log(256), rounded up.
+    var b256 = new Uint8Array(size)
+        // Process the characters.
+    while (source[psz]) {
+            // Decode character
+      var carry = BASE_MAP[source.charCodeAt(psz)]
+            // Invalid character
+      if (carry === 255) { return }
+      var i = 0
+      for (var it3 = size - 1; (carry !== 0 || i < length) && (it3 !== -1); it3--, i++) {
+        carry += (BASE * b256[it3]) >>> 0
+        b256[it3] = (carry % 256) >>> 0
+        carry = (carry / 256) >>> 0
+      }
+      if (carry !== 0) { throw new Error('Non-zero carry') }
+      length = i
+      psz++
+    }
+        // Skip trailing spaces.
+    if (source[psz] === ' ') { return }
+        // Skip leading zeroes in b256.
+    var it4 = size - length
+    while (it4 !== size && b256[it4] === 0) {
+      it4++
+    }
+    var vch = _Buffer.allocUnsafe(zeroes + (size - it4))
+    vch.fill(0x00, 0, zeroes)
+    var j = zeroes
+    while (it4 !== size) {
+      vch[j++] = b256[it4++]
+    }
+    return vch
+  }
+  function decode (string) {
+    var buffer = decodeUnsafe(string)
+    if (buffer) { return buffer }
+    throw new Error('Non-base' + BASE + ' character')
+  }
+  return {
+    encode: encode,
+    decodeUnsafe: decodeUnsafe,
+    decode: decode
+  }
+}
+module.exports = base

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -4,9 +4,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-const Buffer = require('safe-buffer').Buffer
+// @ts-ignore
+const _Buffer = require('safe-buffer').Buffer;
 
-module.exports = function base (ALPHABET) {
+function base (ALPHABET: string) {
   if (ALPHABET.length >= 255) throw new TypeError('Alphabet too long')
 
   const BASE_MAP = new Uint8Array(256)
@@ -25,8 +26,8 @@ module.exports = function base (ALPHABET) {
   const FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   const iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
 
-  function encode (source) {
-    if (!Buffer.isBuffer(source)) throw new TypeError('Expected Buffer')
+  function encode (source: Buffer) {
+    if (!_Buffer.isBuffer(source)) throw new TypeError('Expected Buffer')
     if (source.length === 0) return ''
 
     // Skip & count leading zeroes.
@@ -50,9 +51,9 @@ module.exports = function base (ALPHABET) {
 
       // Apply "b58 = b58 * 256 + ch".
       let i = 0
-      for (let it = size - 1; (carry !== 0 || i < length) && (it !== -1); it--, i++) {
-        carry += (256 * b58[it]) >>> 0
-        b58[it] = (carry % BASE) >>> 0
+      for (let it1 = size - 1; (carry !== 0 || i < length) && (it1 !== -1); it1--, i++) {
+        carry += (256 * b58[it1]) >>> 0
+        b58[it1] = (carry % BASE) >>> 0
         carry = (carry / BASE) >>> 0
       }
 
@@ -62,21 +63,21 @@ module.exports = function base (ALPHABET) {
     }
 
     // Skip leading zeroes in base58 result.
-    let it = size - length
-    while (it !== size && b58[it] === 0) {
-      it++
+    let it2 = size - length
+    while (it2 !== size && b58[it2] === 0) {
+      it2++
     }
 
     // Translate the result into a string.
     let str = LEADER.repeat(zeroes)
-    for (; it < size; ++it) str += ALPHABET.charAt(b58[it])
+    for (; it2 < size; ++it2) str += ALPHABET.charAt(b58[it2])
 
     return str
   }
 
-  function decodeUnsafe (source) {
+  function decodeUnsafe (source: string): Buffer | undefined {
     if (typeof source !== 'string') throw new TypeError('Expected String')
-    if (source.length === 0) return Buffer.alloc(0)
+    if (source.length === 0) return _Buffer.alloc(0)
 
     let psz = 0
 
@@ -104,9 +105,9 @@ module.exports = function base (ALPHABET) {
       if (carry === 255) return
 
       let i = 0
-      for (let it = size - 1; (carry !== 0 || i < length) && (it !== -1); it--, i++) {
-        carry += (BASE * b256[it]) >>> 0
-        b256[it] = (carry % 256) >>> 0
+      for (let it3 = size - 1; (carry !== 0 || i < length) && (it3 !== -1); it3--, i++) {
+        carry += (BASE * b256[it3]) >>> 0
+        b256[it3] = (carry % 256) >>> 0
         carry = (carry / 256) >>> 0
       }
 
@@ -119,23 +120,23 @@ module.exports = function base (ALPHABET) {
     if (source[psz] === ' ') return
 
     // Skip leading zeroes in b256.
-    let it = size - length
-    while (it !== size && b256[it] === 0) {
-      it++
+    let it4 = size - length
+    while (it4 !== size && b256[it4] === 0) {
+      it4++
     }
 
-    const vch = Buffer.allocUnsafe(zeroes + (size - it))
+    const vch = _Buffer.allocUnsafe(zeroes + (size - it4))
     vch.fill(0x00, 0, zeroes)
 
     let j = zeroes
-    while (it !== size) {
-      vch[j++] = b256[it++]
+    while (it4 !== size) {
+      vch[j++] = b256[it4++]
     }
 
     return vch
   }
 
-  function decode (string) {
+  function decode (string: string): Buffer {
     const buffer = decodeUnsafe(string)
     if (buffer) return buffer
 
@@ -148,3 +149,5 @@ module.exports = function base (ALPHABET) {
     decode: decode
   }
 }
+
+export = base;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "commonjs",
+    "outDir": "./src",
+    "declaration": true,
+    "rootDir": "./ts_src",
+    "types": [
+      "node"
+    ],
+    "allowJs": false,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": [
+      "ts_src/**/*.ts"
+  ],
+  "exclude": [
+      "**/*.spec.ts",
+      "node_modules/**/*"
+  ]
+}


### PR DESCRIPTION
1. Commit JS source for verifiability.
2. Target ES5 closes #51 

Javascript transpilers will some day insert private key stealing virus into some React Native app and people will wonder what happened......

But for now, as long as we commit and track the JS changes, we can verify that nothing is wrong on OUR end.

Now types are supported too, hooray.