### PR TITLE
Allow Array and Uint8Array like 3.0.4

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@ declare function base(ALPHABET: string): base.BaseConverter;
 export = base;
 declare namespace base {
     interface BaseConverter {
-        encode(buffer: Buffer): string;
+        encode(buffer: ArrayLike<number>): string;
         decodeUnsafe(string: string): Buffer | undefined;
         decode(string: string): Buffer;
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@ declare function base(ALPHABET: string): base.BaseConverter;
 export = base;
 declare namespace base {
     interface BaseConverter {
-        encode(buffer: ArrayLike<number>): string;
+        encode(buffer: Buffer | number[] | Uint8Array): string;
         decodeUnsafe(string: string): Buffer | undefined;
         decode(string: string): Buffer;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ function base (ALPHABET) {
   var FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   var iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
   function encode (source) {
+    if (Array.isArray(source) || source instanceof Uint8Array) { source = _Buffer.from(source) }
     if (!_Buffer.isBuffer(source)) { throw new TypeError('Expected Buffer') }
     if (source.length === 0) { return '' }
         // Skip & count leading zeroes.

--- a/test/index.js
+++ b/test/index.js
@@ -55,3 +55,11 @@ tape.test('encode throws on string', function (t) {
     base.encode('a')
   }, new RegExp('^TypeError: Expected Buffer$'))
 })
+
+tape.test('encode not throw on Array or Uint8Array', function (t) {
+  var base = bases.base58
+
+  t.plan(2)
+  t.same(base.encode([42, 12, 34]), 'F89f')
+  t.same(base.encode(new Uint8Array([42, 12, 34])), 'F89f')
+})

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -28,7 +28,7 @@ function base (ALPHABET: string): base.BaseConverter {
   const FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   const iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
 
-  function encode (source: ArrayLike<number>): string {
+  function encode (source: Buffer | number[] | Uint8Array): string {
     if (Array.isArray(source) || source instanceof Uint8Array) source = _Buffer.from(source)
     if (!_Buffer.isBuffer(source)) throw new TypeError('Expected Buffer')
     if (source.length === 0) return ''
@@ -157,7 +157,7 @@ export = base;
 
 declare namespace base {
     interface BaseConverter {
-        encode(buffer: ArrayLike<number>): string;
+        encode(buffer: Buffer | number[] | Uint8Array): string;
         decodeUnsafe(string: string): Buffer | undefined;
         decode(string: string): Buffer;
     }

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -28,7 +28,8 @@ function base (ALPHABET: string): base.BaseConverter {
   const FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   const iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
 
-  function encode (source: Buffer): string {
+  function encode (source: ArrayLike<number>): string {
+    if (Array.isArray(source) || source instanceof Uint8Array) source = _Buffer.from(source)
     if (!_Buffer.isBuffer(source)) throw new TypeError('Expected Buffer')
     if (source.length === 0) return ''
 
@@ -156,7 +157,7 @@ export = base;
 
 declare namespace base {
     interface BaseConverter {
-        encode(buffer: Buffer): string;
+        encode(buffer: ArrayLike<number>): string;
         decodeUnsafe(string: string): Buffer | undefined;
         decode(string: string): Buffer;
     }


### PR DESCRIPTION
Fixes #63 

This was a breaking change in 3.0.5 from 3.0.4.

We should revert the behavior back, then maybe require Buffer in v4.