### PR TITLE
feature: remove node Buffers and return Uint8Arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@types/node": "12.0.10",
     "standard": "^10.0.3",
     "tape": "^4.5.1",
-    "typescript": "3.5.2",
-    "uint8arrays": "^1.0.0"
+    "typescript": "3.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,9 +41,7 @@
     "@types/node": "12.0.10",
     "standard": "^10.0.3",
     "tape": "^4.5.1",
-    "typescript": "3.5.2"
-  },
-  "dependencies": {
-    "safe-buffer": "^5.0.1"
+    "typescript": "3.5.2",
+    "uint8arrays": "^1.0.0"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,7 @@ declare function base(ALPHABET: string): base.BaseConverter;
 export = base;
 declare namespace base {
     interface BaseConverter {
-        encode(buffer: Uint8Array | number[] | Uint8Array): string;
+        encode(buffer: Uint8Array | number[]): string;
         decodeUnsafe(string: string): Uint8Array | undefined;
         decode(string: string): Uint8Array;
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,9 @@
-/// <reference types="node" />
 declare function base(ALPHABET: string): base.BaseConverter;
 export = base;
 declare namespace base {
     interface BaseConverter {
-        encode(buffer: Buffer | number[] | Uint8Array): string;
-        decodeUnsafe(string: string): Buffer | undefined;
-        decode(string: string): Buffer;
+        encode(buffer: Uint8Array | number[] | Uint8Array): string;
+        decodeUnsafe(string: string): Uint8Array | undefined;
+        decode(string: string): Uint8Array;
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,9 @@ function base (ALPHABET) {
   var FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   var iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
   function encode (source) {
-    if (Array.isArray(source)) { source = Uint8Array.from(source) }
+    if (source instanceof Uint8Array) {}
+    else if (ArrayBuffer.isView(source)) { source = new Uint8Array(source.buffer, source.byteOffset, source.byteLength) }
+    else if (Array.isArray(source)) { source = Uint8Array.from(source) }
     if (!(source instanceof Uint8Array)) { throw new TypeError('Expected Uint8Array') }
     if (source.length === 0) { return '' }
         // Skip & count leading zeroes.

--- a/src/index.js
+++ b/src/index.js
@@ -21,9 +21,7 @@ function base (ALPHABET) {
   var FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   var iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
   function encode (source) {
-    if (source instanceof Uint8Array) {}
-    else if (ArrayBuffer.isView(source)) { source = new Uint8Array(source.buffer, source.byteOffset, source.byteLength) }
-    else if (Array.isArray(source)) { source = Uint8Array.from(source) }
+    if (source instanceof Uint8Array) {} else if (ArrayBuffer.isView(source)) { source = new Uint8Array(source.buffer, source.byteOffset, source.byteLength) } else if (Array.isArray(source)) { source = Uint8Array.from(source) }
     if (!(source instanceof Uint8Array)) { throw new TypeError('Expected Uint8Array') }
     if (source.length === 0) { return '' }
         // Skip & count leading zeroes.

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ function base (ALPHABET) {
   var iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
   function encode (source) {
     if (source instanceof Uint8Array) {
-
     } else if (ArrayBuffer.isView(source)) {
       source = new Uint8Array(source.buffer, source.byteOffset, source.byteLength)
     } else if (Array.isArray(source)) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,6 @@
 // Copyright (c) 2014-2018 The Bitcoin Core developers (base58.cpp)
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-// @ts-ignore
-var _Buffer = require('safe-buffer').Buffer
 function base (ALPHABET) {
   if (ALPHABET.length >= 255) { throw new TypeError('Alphabet too long') }
   var BASE_MAP = new Uint8Array(256)
@@ -23,8 +21,8 @@ function base (ALPHABET) {
   var FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   var iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
   function encode (source) {
-    if (Array.isArray(source) || source instanceof Uint8Array) { source = _Buffer.from(source) }
-    if (!_Buffer.isBuffer(source)) { throw new TypeError('Expected Buffer') }
+    if (Array.isArray(source)) { source = Uint8Array.from(source) }
+    if (!(source instanceof Uint8Array)) { throw new TypeError('Expected Uint8Array') }
     if (source.length === 0) { return '' }
         // Skip & count leading zeroes.
     var zeroes = 0
@@ -64,7 +62,7 @@ function base (ALPHABET) {
   }
   function decodeUnsafe (source) {
     if (typeof source !== 'string') { throw new TypeError('Expected String') }
-    if (source.length === 0) { return _Buffer.alloc(0) }
+    if (source.length === 0) { return new Uint8Array() }
     var psz = 0
         // Skip leading spaces.
     if (source[psz] === ' ') { return }
@@ -101,8 +99,7 @@ function base (ALPHABET) {
     while (it4 !== size && b256[it4] === 0) {
       it4++
     }
-    var vch = _Buffer.allocUnsafe(zeroes + (size - it4))
-    vch.fill(0x00, 0, zeroes)
+    var vch = new Uint8Array(zeroes + (size - it4))
     var j = zeroes
     while (it4 !== size) {
       vch[j++] = b256[it4++]

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,13 @@ function base (ALPHABET) {
   var FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   var iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
   function encode (source) {
-    if (source instanceof Uint8Array) {} else if (ArrayBuffer.isView(source)) { source = new Uint8Array(source.buffer, source.byteOffset, source.byteLength) } else if (Array.isArray(source)) { source = Uint8Array.from(source) }
+    if (source instanceof Uint8Array) {
+
+    } else if (ArrayBuffer.isView(source)) {
+      source = new Uint8Array(source.buffer, source.byteOffset, source.byteLength)
+    } else if (Array.isArray(source)) {
+      source = Uint8Array.from(source)
+    }
     if (!(source instanceof Uint8Array)) { throw new TypeError('Expected Uint8Array') }
     if (source.length === 0) { return '' }
         // Skip & count leading zeroes.

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,22 @@
 var basex = require('../')
 var tape = require('tape')
 var fixtures = require('./fixtures.json')
-var uint8ArrayFromString = require('uint8arrays/from-string')
-var uint8ArrayToString = require('uint8arrays/to-string')
+
+const uint8ArrayToHexString = (uint8) => {
+  return Array.from(uint8).reduce((acc, curr) => `${acc}${curr.toString(16).padStart(2, '0')}`, '')
+}
+
+const uint8ArrayFromHexString = (string) => {
+  if (!string.length) {
+    return new Uint8Array(0)
+  }
+
+  if (string.length % 2 !== 0) {
+    throw new Error('Invalid hex string')
+  }
+
+  return new Uint8Array(string.match(/.{1,2}/g).map(byte => parseInt(byte, 16)))
+}
 
 var bases = Object.keys(fixtures.alphabets).reduce(function (bases, alphabetName) {
   bases[alphabetName] = basex(fixtures.alphabets[alphabetName])
@@ -12,7 +26,7 @@ var bases = Object.keys(fixtures.alphabets).reduce(function (bases, alphabetName
 fixtures.valid.forEach(function (f) {
   tape.test('can encode ' + f.alphabet + ': ' + f.hex, function (t) {
     var base = bases[f.alphabet]
-    var actual = base.encode(uint8ArrayFromString(f.hex, 'base16'))
+    var actual = base.encode(uint8ArrayFromHexString(f.hex))
 
     t.plan(1)
     t.same(actual, f.string)
@@ -22,7 +36,7 @@ fixtures.valid.forEach(function (f) {
 fixtures.valid.forEach(function (f) {
   tape.test('can decode ' + f.alphabet + ': ' + f.string, function (t) {
     var base = bases[f.alphabet]
-    var actual = uint8ArrayToString(base.decode(f.string), 'base16')
+    var actual = uint8ArrayToHexString(base.decode(f.string))
 
     t.plan(1)
     t.same(actual, f.hex)

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,8 @@
-var Buffer = require('safe-buffer').Buffer
 var basex = require('../')
 var tape = require('tape')
 var fixtures = require('./fixtures.json')
+var uint8ArrayFromString = require('uint8arrays/from-string')
+var uint8ArrayToString = require('uint8arrays/to-string')
 
 var bases = Object.keys(fixtures.alphabets).reduce(function (bases, alphabetName) {
   bases[alphabetName] = basex(fixtures.alphabets[alphabetName])
@@ -11,7 +12,7 @@ var bases = Object.keys(fixtures.alphabets).reduce(function (bases, alphabetName
 fixtures.valid.forEach(function (f) {
   tape.test('can encode ' + f.alphabet + ': ' + f.hex, function (t) {
     var base = bases[f.alphabet]
-    var actual = base.encode(Buffer.from(f.hex, 'hex'))
+    var actual = base.encode(uint8ArrayFromString(f.hex, 'base16'))
 
     t.plan(1)
     t.same(actual, f.string)
@@ -21,7 +22,7 @@ fixtures.valid.forEach(function (f) {
 fixtures.valid.forEach(function (f) {
   tape.test('can decode ' + f.alphabet + ': ' + f.string, function (t) {
     var base = bases[f.alphabet]
-    var actual = base.decode(f.string).toString('hex')
+    var actual = uint8ArrayToString(base.decode(f.string), 'base16')
 
     t.plan(1)
     t.same(actual, f.hex)
@@ -41,10 +42,10 @@ fixtures.invalid.forEach(function (f) {
   })
 })
 
-tape.test('decode should return Buffer', function (t) {
+tape.test('decode should return Uint8Array', function (t) {
   t.plan(2)
-  t.true(Buffer.isBuffer(bases.base2.decode('')))
-  t.true(Buffer.isBuffer(bases.base2.decode('01')))
+  t.true(bases.base2.decode('') instanceof Uint8Array)
+  t.true(bases.base2.decode('01') instanceof Uint8Array)
 })
 
 tape.test('encode throws on string', function (t) {
@@ -53,7 +54,7 @@ tape.test('encode throws on string', function (t) {
   t.plan(1)
   t.throws(function () {
     base.encode('a')
-  }, new RegExp('^TypeError: Expected Buffer$'))
+  }, new RegExp('^TypeError: Expected Uint8Array$'))
 })
 
 tape.test('encode not throw on Array or Uint8Array', function (t) {

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -26,7 +26,12 @@ function base (ALPHABET: string): base.BaseConverter {
   const iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
 
   function encode (source: Uint8Array | number[]): string {
-    if (Array.isArray(source)) source = Uint8Array.from(source)
+    if (source instanceof Uint8Array) {
+    } else if (ArrayBuffer.isView(source)) {
+      source = new Uint8Array(source.buffer, source.byteOffset, source.byteLength)
+    } else if (Array.isArray(source)) {
+      source = Uint8Array.from(source)
+    }
     if (!(source instanceof Uint8Array)) throw new TypeError('Expected Uint8Array')
     if (source.length === 0) return ''
 

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -25,7 +25,7 @@ function base (ALPHABET: string): base.BaseConverter {
   const FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   const iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
 
-  function encode (source: Uint8Array | number[] | Uint8Array): string {
+  function encode (source: Uint8Array | number[]): string {
     if (Array.isArray(source)) source = Uint8Array.from(source)
     if (!(source instanceof Uint8Array)) throw new TypeError('Expected Uint8Array')
     if (source.length === 0) return ''
@@ -153,7 +153,7 @@ export = base;
 
 declare namespace base {
     interface BaseConverter {
-        encode(buffer: Uint8Array | number[] | Uint8Array): string;
+        encode(buffer: Uint8Array | number[]): string;
         decodeUnsafe(string: string): Uint8Array | undefined;
         decode(string: string): Uint8Array;
     }

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -4,9 +4,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-// @ts-ignore
-const _Buffer = require('safe-buffer').Buffer;
-
 function base (ALPHABET: string): base.BaseConverter {
   if (ALPHABET.length >= 255) throw new TypeError('Alphabet too long')
 
@@ -28,9 +25,9 @@ function base (ALPHABET: string): base.BaseConverter {
   const FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   const iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
 
-  function encode (source: Buffer | number[] | Uint8Array): string {
-    if (Array.isArray(source) || source instanceof Uint8Array) source = _Buffer.from(source)
-    if (!_Buffer.isBuffer(source)) throw new TypeError('Expected Buffer')
+  function encode (source: Uint8Array | number[] | Uint8Array): string {
+    if (Array.isArray(source)) source = Uint8Array.from(source)
+    if (!(source instanceof Uint8Array)) throw new TypeError('Expected Uint8Array')
     if (source.length === 0) return ''
 
     // Skip & count leading zeroes.
@@ -78,9 +75,9 @@ function base (ALPHABET: string): base.BaseConverter {
     return str
   }
 
-  function decodeUnsafe (source: string): Buffer | undefined {
+  function decodeUnsafe (source: string): Uint8Array | undefined {
     if (typeof source !== 'string') throw new TypeError('Expected String')
-    if (source.length === 0) return _Buffer.alloc(0)
+    if (source.length === 0) return new Uint8Array()
 
     let psz = 0
 
@@ -128,8 +125,7 @@ function base (ALPHABET: string): base.BaseConverter {
       it4++
     }
 
-    const vch = _Buffer.allocUnsafe(zeroes + (size - it4))
-    vch.fill(0x00, 0, zeroes)
+    const vch = new Uint8Array(zeroes + (size - it4))
 
     let j = zeroes
     while (it4 !== size) {
@@ -139,7 +135,7 @@ function base (ALPHABET: string): base.BaseConverter {
     return vch
   }
 
-  function decode (string: string): Buffer {
+  function decode (string: string): Uint8Array {
     const buffer = decodeUnsafe(string)
     if (buffer) return buffer
 
@@ -157,8 +153,8 @@ export = base;
 
 declare namespace base {
     interface BaseConverter {
-        encode(buffer: Buffer | number[] | Uint8Array): string;
-        decodeUnsafe(string: string): Buffer | undefined;
-        decode(string: string): Buffer;
+        encode(buffer: Uint8Array | number[] | Uint8Array): string;
+        decodeUnsafe(string: string): Uint8Array | undefined;
+        decode(string: string): Uint8Array;
     }
 }


### PR DESCRIPTION
Instead of returning node `Buffer`s, this PR changes the API to return `Uint8Array`s.

The node `Buffer` polyfill is large and it's not bundled by default with webpack any more.

The parts of the `Buffer` API that most modules use are covered by the browser-native [DataView](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) class, and of course `Buffer` is a subclass of `Uint8Array` so there's isn't a very compelling reason to use Buffers in the future if you're doing anything in the browser.

Running the benchmarks shows a similar performance profile:

```
Buffer
Seed: 75efba4518adf21b9f7e6a27faf53f47
--------------------------------------------------
encode x 327,499 ops/sec ±1.69% (9 runs sampled)
decode x 357,884 ops/sec ±0.99% (9 runs sampled)
==================================================
```
```
Uint8Array
Seed: 5f5b48aa221926d365aeb0f8e01997bf
--------------------------------------------------
encode x 315,904 ops/sec ±2.34% (9 runs sampled)
decode x 342,451 ops/sec ±1.96% (7 runs sampled)
==================================================
```

BREAKING CHANGE:

- `decodeUnsafe` and `decode` previously returned node `Buffer`s, they now return `Uint8Array`s