### PR TITLE
use Uint8Array as an encode argument

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@ declare function base(ALPHABET: string): base.BaseConverter;
 export = base;
 declare namespace base {
     interface BaseConverter {
-        encode(buffer: Buffer | number[] | Uint8Array): string;
+        encode(bytes: Uint8Array | number[]): string;
         decodeUnsafe(string: string): Buffer | undefined;
         decode(string: string): Buffer;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,8 @@ function base (ALPHABET) {
   var FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   var iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
   function encode (source) {
-    if (Array.isArray(source) || source instanceof Uint8Array) { source = _Buffer.from(source) }
-    if (!_Buffer.isBuffer(source)) { throw new TypeError('Expected Buffer') }
+        // Just to avoid instanceof twice
+    if (source instanceof Uint8Array) { void 0 } else if (Array.isArray(source)) { source = Uint8Array.from(source) } else { throw new TypeError('Expected Uint8Array') }
     if (source.length === 0) { return '' }
         // Skip & count leading zeroes.
     var zeroes = 0

--- a/test/index.js
+++ b/test/index.js
@@ -53,7 +53,7 @@ tape.test('encode throws on string', function (t) {
   t.plan(1)
   t.throws(function () {
     base.encode('a')
-  }, new RegExp('^TypeError: Expected Buffer$'))
+  }, new RegExp('^TypeError: Expected Uint8Array$'))
 })
 
 tape.test('encode not throw on Array or Uint8Array', function (t) {

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -28,9 +28,11 @@ function base (ALPHABET: string): base.BaseConverter {
   const FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
   const iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
 
-  function encode (source: Buffer | number[] | Uint8Array): string {
-    if (Array.isArray(source) || source instanceof Uint8Array) source = _Buffer.from(source)
-    if (!_Buffer.isBuffer(source)) throw new TypeError('Expected Buffer')
+  function encode (source: Uint8Array | number[]): string {
+    // Just to avoid instanceof twice
+    if (source instanceof Uint8Array) void 0
+    else if (Array.isArray(source)) source = Uint8Array.from(source)
+    else throw new TypeError('Expected Uint8Array')
     if (source.length === 0) return ''
 
     // Skip & count leading zeroes.
@@ -157,7 +159,7 @@ export = base;
 
 declare namespace base {
     interface BaseConverter {
-        encode(buffer: Buffer | number[] | Uint8Array): string;
+        encode(bytes: Uint8Array | number[]): string;
         decodeUnsafe(string: string): Buffer | undefined;
         decode(string: string): Buffer;
     }


### PR DESCRIPTION
This is slightly reduced in scope version of #68 which is not a breaking change for libraries downstream.

Before

```
Seed: 1e15efc4cbae18af002c915c6f93bb65
--------------------------------------------------
encode x 164,655 ops/sec ±27.37% (8 runs sampled)
decode x 229,892 ops/sec ±9.57% (8 runs sampled)
==================================================
```

After: 

```
Seed: af0de9f733fe3e9bd1bdeb6f1330e6e2
--------------------------------------------------
encode x 241,838 ops/sec ±8.57% (9 runs sampled)
decode x 233,887 ops/sec ±4.73% (9 runs sampled)
==================================================
```