### PR TITLE
refactor: swap out safe-buffer with buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "typescript": "3.5.2"
   },
   "dependencies": {
-    "safe-buffer": "^5.0.1"
+    "buffer": "^6.0.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 // @ts-ignore
-var _Buffer = require('safe-buffer').Buffer
+var _Buffer = require('buffer/').Buffer
 function base (ALPHABET) {
   if (ALPHABET.length >= 255) { throw new TypeError('Alphabet too long') }
   var BASE_MAP = new Uint8Array(256)

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-var Buffer = require('safe-buffer').Buffer
+var Buffer = require('buffer/').Buffer
 var basex = require('../')
 var tape = require('tape')
 var fixtures = require('./fixtures.json')

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -5,7 +5,7 @@
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 // @ts-ignore
-const _Buffer = require('safe-buffer').Buffer;
+const _Buffer = require('buffer/').Buffer;
 
 function base (ALPHABET: string): base.BaseConverter {
   if (ALPHABET.length >= 255) throw new TypeError('Alphabet too long')


### PR DESCRIPTION
Webpack 5 does not polyfill Node.js standard libraries anymore. Using [buffer](https://www.npmjs.com/package/buffer) instead of safe-buffer should ensure that developers using Webpack 5 can use your library without having to polyfill the Node.js buffer standard library module themselves.