### PR TITLE
Improve decoding performance

### DIFF
--- a/src/cjs/index.cjs
+++ b/src/cjs/index.cjs
@@ -81,7 +81,7 @@ function base (ALPHABET) {
     const size = (((source.length - psz) * FACTOR) + 1) >>> 0 // log(58) / log(256), rounded up.
     const b256 = new Uint8Array(size)
     // Process the characters.
-    while (source[psz]) {
+    while (psz < source.length) {
       // Decode character
       let carry = BASE_MAP[source.charCodeAt(psz)]
       // Invalid character

--- a/src/esm/index.js
+++ b/src/esm/index.js
@@ -79,7 +79,7 @@ function base (ALPHABET) {
     const size = (((source.length - psz) * FACTOR) + 1) >>> 0 // log(58) / log(256), rounded up.
     const b256 = new Uint8Array(size)
     // Process the characters.
-    while (source[psz]) {
+    while (psz < source.length) {
       // Decode character
       let carry = BASE_MAP[source.charCodeAt(psz)]
       // Invalid character

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -100,7 +100,7 @@ function base (ALPHABET: string): base.BaseConverter {
     const b256 = new Uint8Array(size)
 
     // Process the characters.
-    while (source[psz]) {
+    while (psz < source.length) {
       // Decode character
       let carry = BASE_MAP[source.charCodeAt(psz)]
 


### PR DESCRIPTION
This yields a performance improvement over indexing into `source` over and over. `source` is asserted to be a string, `psz` is monotonically increasing, and `psz >= source.length` is a good indication that you've run out of characters.

Originally proposed by @oscxc in #74.

## Benchmarks

```shell
cd benchmark/
(cd ../ && npm run build) && SEED=8854dc2a353e143702ef1b29874b63a4 npm start
```

### Before

```shell
> base-x-benchmark@0.0.0 start
> node index.js

Seed: 8854dc2a353e143702ef1b29874b63a4
--------------------------------------------------
encode x 389,286 ops/sec ±0.21% (8 runs sampled)
decode x 415,231 ops/sec ±0.91% (9 runs sampled)
==================================================
```

### After

```shell
> base-x-benchmark@0.0.0 start
> node index.js

Seed: 8854dc2a353e143702ef1b29874b63a4
--------------------------------------------------
encode x 389,695 ops/sec ±0.12% (9 runs sampled)
decode x 449,877 ops/sec ±0.13% (9 runs sampled)
==================================================
```