### PR TITLE
Prohibit char codes that would overflow the `BASE_MAP`

### DIFF
--- a/src/cjs/index.cjs
+++ b/src/cjs/index.cjs
@@ -82,8 +82,12 @@ function base (ALPHABET) {
     const b256 = new Uint8Array(size)
     // Process the characters.
     while (psz < source.length) {
+      // Find code of next character
+      const charCode = source.charCodeAt(psz)
+      // Base map can not be indexed using char code
+      if (charCode > 255) { return }
       // Decode character
-      let carry = BASE_MAP[source.charCodeAt(psz)]
+      let carry = BASE_MAP[charCode]
       // Invalid character
       if (carry === 255) { return }
       let i = 0

--- a/src/esm/index.js
+++ b/src/esm/index.js
@@ -80,8 +80,12 @@ function base (ALPHABET) {
     const b256 = new Uint8Array(size)
     // Process the characters.
     while (psz < source.length) {
+      // Find code of next character
+      const charCode = source.charCodeAt(psz)
+      // Base map can not be indexed using char code
+      if (charCode > 255) { return }
       // Decode character
-      let carry = BASE_MAP[source.charCodeAt(psz)]
+      let carry = BASE_MAP[charCode]
       // Invalid character
       if (carry === 255) { return }
       let i = 0

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -660,6 +660,12 @@
       "alphabet": "0123456789fabcdef",
       "description": "poorly formed alphabet",
       "exception": "^TypeError: f is ambiguous$"
+    },
+    {
+      "alphabet": "base58",
+      "description": "character whose code exceeds the highest index of base map (>=256)",
+      "exception": "^Error: Non-base58 character$",
+      "string": "\u1000"
     }
   ]
 }

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -101,8 +101,14 @@ function base (ALPHABET: string): base.BaseConverter {
 
     // Process the characters.
     while (psz < source.length) {
+      // Find code of next character
+      const charCode = source.charCodeAt(psz)
+
+      // Base map can not be indexed using char code
+      if (charCode > 255) return
+
       // Decode character
-      let carry = BASE_MAP[source.charCodeAt(psz)]
+      let carry = BASE_MAP[charCode]
 
       // Invalid character
       if (carry === 255) return


### PR DESCRIPTION
# Problem

Consider the char code of a character. Codes >255 are prohibited when constructing an alphabet (throws `new TypeError(x + ' is ambiguous')`) but they are _accepted_ when decoding a string.

```ts
const bs58 = base('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz');
const str = 'ABC' + /* char code 256 */ '\u0100' + 'DEF';
const bytes = bs58.decode(str);  // WORKS
```

That code should absolutely fatal with ‘non-base58 character’.

[Sandbox link](https://codesandbox.io/p/sandbox/cp74y5)

# Bench

## Before

```shell
$ SEED=1c80dc20398124b795fe1bc8f37bd586 npm start

> base-x-benchmark@0.0.0 start
> node index.js

Seed: 1c80dc20398124b795fe1bc8f37bd586
--------------------------------------------------
encode x 371,690 ops/sec ±0.06% (9 runs sampled)
decode x 420,041 ops/sec ±0.12% (9 runs sampled)
==================================================
```

## After

```shell
$ SEED=1c80dc20398124b795fe1bc8f37bd586 npm start

> base-x-benchmark@0.0.0 start
> node index.js

Seed: 1c80dc20398124b795fe1bc8f37bd586
--------------------------------------------------
encode x 378,646 ops/sec ±0.04% (9 runs sampled)
decode x 432,351 ops/sec ±0.14% (9 runs sampled)
==================================================
```

# Backports

* 3.x https://github.com/cryptocoinjs/base-x/pull/87
* 4.x https://github.com/cryptocoinjs/base-x/pull/89
* 5.x https://github.com/cryptocoinjs/base-x/pull/88