### PR TITLE
[backport 4.x] Prohibit char codes that would overflow the `BASE_MAP`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-x",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Fast base encoding / decoding of any given alphabet",
   "keywords": [
     "base-x",

--- a/src/index.js
+++ b/src/index.js
@@ -81,8 +81,12 @@ function base (ALPHABET) {
     var b256 = new Uint8Array(size)
         // Process the characters.
     while (source[psz]) {
+            // Find code of next character
+      var charCode = source.charCodeAt(psz)
+            // Base map can not be indexed using char code
+      if (charCode > 255) { return }
             // Decode character
-      var carry = BASE_MAP[source.charCodeAt(psz)]
+      var carry = BASE_MAP[charCode]
             // Invalid character
       if (carry === 255) { return }
       var i = 0

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -660,6 +660,12 @@
       "alphabet": "0123456789fabcdef",
       "description": "poorly formed alphabet",
       "exception": "^TypeError: f is ambiguous$"
+    },
+    {
+      "alphabet": "base58",
+      "description": "character whose code exceeds the highest index of base map (>=256)",
+      "exception": "^Error: Non-base58 character$",
+      "string": "\u1000"
     }
   ]
 }

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -100,8 +100,14 @@ function base (ALPHABET: string): base.BaseConverter {
 
     // Process the characters.
     while (source[psz]) {
+      // Find code of next character
+      const charCode = source.charCodeAt(psz)
+
+      // Base map can not be indexed using char code
+      if (charCode > 255) return
+
       // Decode character
-      let carry = BASE_MAP[source.charCodeAt(psz)]
+      let carry = BASE_MAP[charCode]
 
       // Invalid character
       if (carry === 255) return


### PR DESCRIPTION
See #86.

> [!NOTE]
> Will need a new branch in the source called `v4.x`